### PR TITLE
chore: targetSdk 36対応、v1.2.0リリース

### DIFF
--- a/.github/workflows/deploy-google-play-console.yml
+++ b/.github/workflows/deploy-google-play-console.yml
@@ -33,15 +33,15 @@ jobs:
           track: internal
           whatsNewDirectory: distribution/whatsnew
 
-      # Instant版のデプロイ
-      - name: Deploy Instant App to Play Store
-        uses: r0adkll/upload-google-play@v1.0.15
-        with:
-          serviceAccountJson: service_account.json
-          packageName: com.kireaji.instantqrreader
-          releaseFiles: app/build/outputs/bundle/instantRelease/*.aab
-          track: instant:internal
-          whatsNewDirectory: distribution/whatsnew
+      # Instant版のデプロイ (現在無効化 - Google Play Console でトラック設定後に有効化)
+      # - name: Deploy Instant App to Play Store
+      #   uses: r0adkll/upload-google-play@v1.0.15
+      #   with:
+      #     serviceAccountJson: service_account.json
+      #     packageName: com.kireaji.instantqrreader
+      #     releaseFiles: app/build/outputs/bundle/instantRelease/*.aab
+      #     track: instant:internal
+      #     whatsNewDirectory: distribution/whatsnew
 
       - uses: 8398a7/action-slack@v2.5.2
         if: failure()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,12 +17,12 @@ plugins {
 
 android {
     namespace = "com.kireaji.instantqrreader"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.kireaji.instantqrreader"
         minSdk = 28
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,15 +53,15 @@ android {
     flavorDimensions.add("appType")
     productFlavors {
         create("instant") {
-            versionCode = 111
-            versionName = "v1.1.1-instant"
+            versionCode = 120
+            versionName = "v1.2.0-instant"
         }
         create("installed") {
             // 1-2桁revision
             // 3-4桁instant version
             // 5以降はアプリVer
-            versionCode = 11101
-            versionName = "v1.1.1"
+            versionCode = 12001
+            versionName = "v1.2.0"
         }
     }
     compileOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.2.1"
+agp = "8.9.1"
 org-jetbrains-kotlin-android = "1.8.10"
 core-ktx = "1.9.0"
 junit = "4.13.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 09 23:20:14 JST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- targetSdk 36 (Android 16) 対応
- AGP 8.9.1、Gradle 8.11.1 へ更新
- Instant App デプロイを一時無効化
- アプリバージョンを v1.2.0 に更新

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `app/build.gradle.kts` | compileSdk/targetSdk 36、v1.2.0 |
| `gradle/libs.versions.toml` | AGP 8.2.1 → 8.9.1 |
| `gradle/wrapper/gradle-wrapper.properties` | Gradle 8.2 → 8.11.1 |
| `.github/actions/build-release-aab/action.yml` | Instant AAB ビルド追加 |
| `.github/workflows/deploy-google-play-console.yml` | Instant デプロイ無効化 |

## Test plan
- [x] デバッグビルド成功確認済み
- [ ] CI でリリースビルド確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)