### PR TITLE
fix: AndroidManifest.xmlから冗長なlabel属性を削除

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,6 @@
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
             android:exported="true"
-            android:label="@string/app_name"
             android:launchMode="singleInstance"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.InstantQRReader"


### PR DESCRIPTION
RedundantLabel lint警告を修正しました。

## 変更内容
- MainActivityの冗長なandroid:label属性を削除
- Applicationレベルで既に同じラベルを設定済み

## 検証
- ✅ Lint チェックをパス
- ✅ ユニットテストをパス
- ✅ 両フレーバーをビルド成功

Resolves #4

Generated with [Claude Code](https://claude.ai/code)