### PR TITLE
fix: 未使用カラーリソース purple_200 を削除

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>
     <color name="purple_700">#FF3700B3</color>
     <color name="teal_200">#FF03DAC5</color>


### PR DESCRIPTION
Android Lint で報告された未使用リソース R.color.purple_200 を
colors.xml から削除しました。

Fixes #9

Generated with [Claude Code](https://claude.ai/code)